### PR TITLE
Fixed possible Racecondition

### DIFF
--- a/CppSemaphore/cppSemaphore.hpp
+++ b/CppSemaphore/cppSemaphore.hpp
@@ -44,12 +44,14 @@ public:
   std::condition_variable cv;
   std::mutex locker;
   long s_count;
+  std::mutex countLocker;
 };
 
 namespace dispatch {
   
   auto semaphore_signal(dispatch::semaphore_c& semaphore) -> long
   {
+    std::unique_lock<std::mutex> (semaphore.countLocker);
     semaphore.s_count--;
     
     if (semaphore.s_count < 0) {

--- a/CppSemaphore/cppSemaphore.hpp
+++ b/CppSemaphore/cppSemaphore.hpp
@@ -43,18 +43,14 @@ public:
   
   std::condition_variable cv;
   std::mutex locker;
-  long s_count;
-  std::mutex countLocker;
+  std::atomic<long> s_count;
 };
 
 namespace dispatch {
   
   auto semaphore_signal(dispatch::semaphore_c& semaphore) -> long
   {
-    std::unique_lock<std::mutex> (semaphore.countLocker);
-    semaphore.s_count--;
-    
-    if (semaphore.s_count < 0) {
+    if (--semaphore.s_count < 0) {
       semaphore.cv.notify_one();
     }
     return semaphore.s_count;


### PR DESCRIPTION
Fixed a possible racecondition between 

`semaphore.s_count--;` in line 53 and `if (semaphore.s_count < 0) {` in line 55

One Thread could be decrementing the value of count while exactly a separate thread is also decrementing the value of count. Which leads that nether thread is calling `semaphore.cv.notify_one();`